### PR TITLE
Refactor code to never do casts

### DIFF
--- a/src/FormParseNode.php
+++ b/src/FormParseNode.php
@@ -72,7 +72,7 @@ class FormParseNode implements ParseNode
      */
     public function getStringValue(): ?string
     {
-        return is_string($this->node)
+        return is_string($this->node) && !$this->isNull()
             ? urldecode(addcslashes($this->node, "\\\t\r\n"))
             : null;
     }

--- a/src/FormParseNode.php
+++ b/src/FormParseNode.php
@@ -81,7 +81,6 @@ class FormParseNode implements ParseNode
      */
     public function getBooleanValue(): ?bool
     {
-        $validVals = ['true' => true, 'false' => false];
         return (!$this->isNull() && filter_var($this->node, FILTER_VALIDATE_BOOLEAN)) ? boolval($this->node) : null;
     }
 

--- a/src/FormParseNode.php
+++ b/src/FormParseNode.php
@@ -72,8 +72,8 @@ class FormParseNode implements ParseNode
      */
     public function getStringValue(): ?string
     {
-        return !$this->isNull()
-            ? urldecode(addcslashes(strval($this->node), "\\\t\r\n"))
+        return is_string($this->node)
+            ? urldecode(addcslashes($this->node, "\\\t\r\n"))
             : null;
     }
     /**
@@ -81,7 +81,8 @@ class FormParseNode implements ParseNode
      */
     public function getBooleanValue(): ?bool
     {
-        return !$this->isNull() ? (bool)$this->node : null;
+        $validVals = ['true' => true, 'false' => false];
+        return (!$this->isNull() && filter_var($this->node, FILTER_VALIDATE_BOOLEAN)) ? boolval($this->node) : null;
     }
 
     /**
@@ -89,7 +90,7 @@ class FormParseNode implements ParseNode
      */
     public function getIntegerValue(): ?int
     {
-       return !$this->isNull() ? intval($this->node) : null;
+       return !$this->isNull() && filter_var($this->node, FILTER_VALIDATE_INT, FILTER_FLAG_NONE) ? intval($this->node) : null;
     }
 
     /**
@@ -221,7 +222,7 @@ class FormParseNode implements ParseNode
      */
     public function getDateTimeValue(): ?DateTime
     {
-        return $this->node !== null ? new DateTime(strval($this->node)) : null;
+        return is_string($this->node) ? new DateTime($this->node) : null;
     }
 
     /**

--- a/src/FormParseNodeFactory.php
+++ b/src/FormParseNodeFactory.php
@@ -35,6 +35,7 @@ class FormParseNodeFactory implements ParseNodeFactory
                 $finalResult[$key] []= $field[1];
             }
             $fields2 = array_map(fn ($item) => count($item) > 1 ? $item : $item[0], $finalResult);
+            var_dump($fields2);
         } catch (Exception $ex){
             throw new \RuntimeException('The was a problem parsing the response.', 1, $ex);
         }

--- a/src/FormParseNodeFactory.php
+++ b/src/FormParseNodeFactory.php
@@ -35,7 +35,6 @@ class FormParseNodeFactory implements ParseNodeFactory
                 $finalResult[$key] []= $field[1];
             }
             $fields2 = array_map(fn ($item) => count($item) > 1 ? $item : $item[0], $finalResult);
-            var_dump($fields2);
         } catch (Exception $ex){
             throw new \RuntimeException('The was a problem parsing the response.', 1, $ex);
         }

--- a/tests/FormParseNodeTest.php
+++ b/tests/FormParseNodeTest.php
@@ -24,11 +24,14 @@ class FormParseNodeTest extends TestCase
     private StreamInterface $stream;
 
     protected function setUp(): void {
-        $this->stream = Utils::streamFor('@odata.type=Missing&name=Silas+Kenneth&age=98&height=123.122&maritalStatus=complicated,single&type=html&type=json&type=plain');
+        $this->stream = Utils::streamFor('@odata.type=Missing&name=Silas+Kenneth&age=98&height=123.122&maritalStatus=complicated,single&type=html&type=json&type=plain&seen=true');
     }
 
     public function testGetIntegerValue(): void {
-        $this->parseNode = new FormParseNode('1243.78');
+        $this->parseNode = new FormParseNode(1243.78);
+        $expected = $this->parseNode->getIntegerValue();
+        $this->assertEquals(null, $expected);
+        $this->parseNode = new FormParseNode(1243);
         $expected = $this->parseNode->getIntegerValue();
         $this->assertEquals(1243, $expected);
     }
@@ -54,11 +57,12 @@ class FormParseNodeTest extends TestCase
         $this->assertInstanceOf(Enum::class, $expected->getMaritalStatus());
         $this->assertEquals(98, $expected->getAge());
         $this->assertEquals(123.122, $expected->getHeight());
+        $this->assertEquals(true, $expected->getSeen());
         $this->assertEquals([new BioContentType('html'), new BioContentType('json'), new BioContentType('plain')], $expected->getBioContentType());
     }
 
     public function testGetFloatValue(): void {
-        $this->parseNode = new FormParseNode('1243.12');
+        $this->parseNode = new FormParseNode(1243.12);
         $expected = $this->parseNode->getFloatValue();
         $this->assertEquals(1243.12, $expected);
     }
@@ -124,7 +128,7 @@ class FormParseNodeTest extends TestCase
     }
 
     public function testGetBooleanValue(): void {
-        $this->parseNode = new FormParseNode(true);
+        $this->parseNode = new FormParseNode('true');
         $expected = $this->parseNode->getBooleanValue();
         $this->assertEquals('bool', get_debug_type($expected));
         $this->assertEquals(true, $expected);

--- a/tests/Samples/Person.php
+++ b/tests/Samples/Person.php
@@ -21,6 +21,8 @@ class Person implements Parsable, AdditionalDataHolder
 
     /** @var BioContentType[]|null  */
     private ?array $bioContentType = null;
+
+    private ?bool $seen = null;
     /**
      * @inheritDoc
      */
@@ -33,8 +35,25 @@ class Person implements Parsable, AdditionalDataHolder
             "height" => function (ParseNode $n) use ($currentObject) {$currentObject->setHeight($n->getFloatValue());},
             "maritalStatus" => function (ParseNode $n) use ($currentObject) {$currentObject->setMaritalStatus($n->getEnumValue(MaritalStatus::class));},
             "address" => function (ParseNode $n) use ($currentObject) {$currentObject->setAddress($n->getObjectValue(array(Address::class, 'createFromDiscriminatorValue')));},
-            "type" => function (ParseNode $n) use ($currentObject) {$currentObject->setBioContentType($n->getCollectionOfEnumValues(BioContentType::class));}
+            "type" => function (ParseNode $n) use ($currentObject) {$currentObject->setBioContentType($n->getCollectionOfEnumValues(BioContentType::class));},
+            "seen" => function (ParseNode $n) use ($currentObject) {$currentObject->setSeen($n->getBooleanValue());}
         ];
+    }
+
+    /**
+     * @param bool|null $seen
+     */
+    public function setSeen(?bool $seen): void
+    {
+        $this->seen = $seen;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getSeen(): ?bool
+    {
+        return $this->seen;
     }
 
     /**
@@ -45,6 +64,7 @@ class Person implements Parsable, AdditionalDataHolder
         $writer->writeIntegerValue('age', $this->age);
         $writer->writeEnumValue('maritalStatus', $this->maritalStatus);
         $writer->writeFloatValue('height', $this->height);
+        $writer->writeBooleanValue('seen', $this->seen);
         $writer->writeCollectionOfEnumValues('type', $this->bioContentType);
         $writer->writeAdditionalData($this->additionalData);
     }


### PR DESCRIPTION
Given the code
```php
if ($parseNode->getBooleanValue() !== null) {
    $result->setBoolean($parseNode->getBooleanValue());
} else if ($parseNode->getFloatValue() !== null) {
    $result->setDouble($parseNode->getFloatValue());
} else if ($parseNode->getIntegerValue() !== null) {
    $result->setInteger($parseNode->getIntegerValue());
} else if ($parseNode->getStringValue() !== null) {
    $result->setString($parseNode->getStringValue());
}
```


With the current ParseNode implementation, the code will always never go to other branches of the if (unless `getBooleanValue()` returns null) since anything can be cast to boolean making the first branch of the if always true.

This work is part of
https://github.com/microsoft/kiota/issues/2827
